### PR TITLE
feat: Support latest image

### DIFF
--- a/version.rs
+++ b/version.rs
@@ -46,6 +46,13 @@ impl TryFrom<Deployment> for Entry {
                     container: splits[0].to_string(),
                     version: splits[1].to_string(),
                 });
+            } else {
+                return Ok(Entry {
+                    name,
+                    namespace,
+                    container: img.to_string(),
+                    version: String::from("latest"),
+                });
             }
         }
         Err(anyhow::anyhow!("Failed to parse deployment {}", name))


### PR DESCRIPTION
The server did not display the container which image does not contain `:<tag>`.

For example: 

```yaml
    spec:
      containers:
      - name: busybox
        image: busybox
        command:
          - "sh"
          - "-c"
          - "sleep 3600"
 ```