### PR TITLE
Try upgrading all the actions and switch to chainguard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: ci
 on:
   pull_request:
   push:
-    branches:
-      - main
+    #branches:
+    #  - main
 
 env:
   IMAGE: clux/version
@@ -13,7 +13,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Prepare image tags
         id: prep
         run: |
@@ -21,12 +21,12 @@ jobs:
           IMAGE="${{ env.IMAGE }}"
           if curl -sSL https://registry.hub.docker.com/v1/repositories/${IMAGE}/tags | jq -r ".[].name" | grep -q ${TAG}; then
             echo "Semver tag ${TAG} already exists - not publishing"
-            echo ::set-output name=tags::${IMAGE}:latest
+            echo "tags=${IMAGE}:latest" >> $GITHUB_OUTPUT
           else
             echo "Semver tag ${TAG} not found - publishing"
-            echo ::set-output name=tags::${IMAGE}:latest,${IMAGE}:${TAG}
+            echo "tags=${IMAGE}:latest,${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
           fi
-          echo ::set-output name=semver::${TAG}
+          echo "tags=${TAG}" >> $GITHUB_OUTPUT
 
       - uses: docker/setup-buildx-action@v1
         id: buildx
@@ -85,14 +85,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
           components: rustfmt,clippy
-          override: true
-      - name: Run rustfmt
-        run: cargo +nightly fmt -- --check
-      - uses: actions-rs/clippy-check@v1
+      - run: cargo +nightly fmt -- --check
+
+      - uses: giraffate/clippy-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: 'github-pr-review'
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -9,26 +9,20 @@ jobs:
   rustfmt_nightly:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install nightly toolchain with rustfmt available
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          override: true
           components: rustfmt
-
-      - run: rustfmt +nightly --edition 2018 $(find . -type f -iname *.rs)
+      - run: cargo +nightly fmt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           commit-message: rustfmt
           signoff: true
           title: rustfmt
-          body: |
-            Changes from `rustfmt +nightly --edition 2018 $(find . -type f -iname *.rs)`.
+          body: Changes from `cargo +nightly fmt`.
           branch: rustfmt
           # Delete branch when merged
           delete-branch: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN --mount=type=cache,target=/volume/target \
     cargo build --release --bin version && \
     mv /volume/target/x86_64-unknown-linux-musl/release/version .
 
-FROM gcr.io/distroless/static:nonroot
+FROM cgr.dev/chainguard/static
 COPY --from=builder --chown=nonroot:nonroot /volume/version /app/
 EXPOSE 8080
 ENTRYPOINT ["/app/version"]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -101,6 +101,3 @@ spec:
             port: http
           initialDelaySeconds: 5
           periodSeconds: 5
-        env:
-        - name: NAMESPACE
-          value: "default"


### PR DESCRIPTION
- https://github.com/dtolnay/rust-toolchain over [unmaintained actions-rs/toolchain](https://github.com/actions-rs/toolchain/issues/216)
- https://github.com/marketplace/actions/run-clippy-with-reviewdog over [unmaintained ations-rs/clippy-check](https://github.com/actions-rs/clippy-check/issues/162)
- [set-output deprecation fixes](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- bump other action versions