### PR TITLE
Fix docker pushing, caching, and upgrade actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,50 +6,34 @@ on:
     branches:
       - main
 
-env:
-  IMAGE: clux/version
-
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Prepare image tags
-        id: prep
-        run: |
-          TAG=$(grep -E "^version" Cargo.toml | awk -F"\"" '{print $2}' | head -n 1)
-          IMAGE="${{ env.IMAGE }}"
-          echo "semver=${TAG}" >> $GITHUB_OUTPUT
-          if curl -sSL https://registry.hub.docker.com/v1/repositories/${IMAGE}/tags | jq -r ".[].name" | grep -q ${TAG}; then
-            echo "Semver tag ${TAG} already exists - not publishing"
-            echo "enable_semver=false" >> $GITHUB_OUTPUT
-          else
-            echo "Semver tag ${TAG} not found - publishing"
-            echo "enable_semver=true" >> $GITHUB_OUTPUT
-          fi
 
-      - name: Set up Docker Buildx
+      # Build and push with docker buildx
+      - name: Setup docker buildx
         uses: docker/setup-buildx-action@v2
 
-      - uses: docker/metadata-action@v4
+      - name: Configure tags based on git tags + latest
+        uses: docker/metadata-action@v4
         id: meta
         with:
-          images: ${{ env.IMAGE }}
-          labels: |
-            org.opencontainers.image.version=${{ steps.prep.outputs.semver }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.title=${{ env.IMAGE }}
+          images: clux/version
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.prep.outputs.semver }},enable=${{ steps.prep.outputs.enable_semver }}
+            type=pep440,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/login-action@v2
+      - name: Docker login on main origin
+        uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v4
+      - name: Docker buildx and push with GHA cache
+        uses: docker/build-push-action@v4
         with:
           context: .
           # official experimental: https://docs.docker.com/build/ci/github-actions/cache/#github-cache
@@ -57,8 +41,6 @@ jobs:
           cache-to: type=gha,scope=version6,mode=max
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # TODO: append ,linux/arm64
           platforms: linux/amd64
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           TAG=$(grep -E "^version" Cargo.toml | awk -F"\"" '{print $2}' | head -n 1)
           IMAGE="${{ env.IMAGE }}"
+          echo "semver=${TAG}" >> $GITHUB_OUTPUT
           if curl -sSL https://registry.hub.docker.com/v1/repositories/${IMAGE}/tags | jq -r ".[].name" | grep -q ${TAG}; then
             echo "Semver tag ${TAG} already exists - not publishing"
             echo "tags=${IMAGE}:latest" >> $GITHUB_OUTPUT
@@ -26,61 +27,55 @@ jobs:
             echo "Semver tag ${TAG} not found - publishing"
             echo "tags=${IMAGE}:latest,${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
           fi
-          echo "tags=${TAG}" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-buildx-action@v1
-        id: buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Inspect builder
-        run: |
-          echo "Name:      ${{ steps.buildx.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-
-      - uses: docker/metadata-action@v3
-        id: docker_meta
+      - uses: docker/metadata-action@v4
+        id: meta
         with:
           images: ${{ env.IMAGE }}
           labels: |
             org.opencontainers.image.version=${{ steps.prep.outputs.semver }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.title=${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}},value=$(echo "1.3.0"))
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      - uses: docker/login-action@v1
-        if: github.event_name != 'pull_request'
+      - uses: docker/login-action@v2
+        #if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
+      - name: Go Build Cache for Docker
+        uses: actions/cache@v3
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-dockerx6-${{ steps.prep.outputs.semver }}
-          restore-keys: |
-            ${{ runner.os }}-dockerx6-
+          path: rust-cache
+          key: ${{ runner.os }}-rust-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # TODO: fix caching of mount=type=cache (this currently only does layer caching)
-      # https://github.com/kube-rs/version-rs/pull/5#issuecomment-932984323
-      # https://github.com/docker/build-push-action
-      - uses: docker/build-push-action@v2
+      - name: inject rust-cache into docker
+        uses: overmindtech/buildkit-cache-dance/inject@main
         with:
-          builder: ${{ steps.buildx.outputs.name }}
+          cache-source: rust-cache
+
+      - uses: docker/build-push-action@v4
+        with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          #push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # TODO: append ,linux/arm64
           platforms: linux/amd64
-          push: ${{ github.ref == 'refs/heads/master' }}
-          tags: ${{ steps.prep.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          # type=gha seems to be the way forward, but it does not seem to cache mounted cache directories in the build stage only layers
-          # source: https://github.com/moby/buildkit/blob/master/cache/remotecache/gha/gha.go
-          cache-from: type=gha,scope=version5
-          cache-to: type=gha,scope=version5,mode=max
-          # type=local seems to work similarly, needing an extra avoid buildup stage, but also only caches layers and only supports mode=min
-          # https://github.com/docker/build-push-action/issues/252
-          #cache-from: type=local,src=/tmp/.buildx-cache
-          #cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: extract rust-cache from docker
+        uses: overmindtech/buildkit-cache-dance/extract@main
+        with:
+          cache-source: rust-cache
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: ci
 on:
   pull_request:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
 
 env:
   IMAGE: clux/version
@@ -22,8 +22,7 @@ jobs:
           echo "semver=${TAG}" >> $GITHUB_OUTPUT
           if curl -sSL https://registry.hub.docker.com/v1/repositories/${IMAGE}/tags | jq -r ".[].name" | grep -q ${TAG}; then
             echo "Semver tag ${TAG} already exists - not publishing"
-            echo "enable_semver=true" >> $GITHUB_OUTPUT
-            # TODO: false
+            echo "enable_semver=false" >> $GITHUB_OUTPUT
           else
             echo "Semver tag ${TAG} not found - publishing"
             echo "enable_semver=true" >> $GITHUB_OUTPUT
@@ -50,33 +49,26 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Go Build Cache for Docker
-        uses: actions/cache@v3
-        with:
-          path: rust-cache
-          key: ${{ runner.os }}-rust-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: inject rust-cache into docker
-        uses: overmindtech/buildkit-cache-dance/inject@main
-        with:
-          cache-source: rust-cache
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ steps.prep.outputs.semver }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
 
       - uses: docker/build-push-action@v4
         with:
           context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # official experimental: https://docs.docker.com/build/ci/github-actions/cache/#github-cache
+          cache-from: type=gha,scope=version6
+          cache-to: type=gha,scope=version6,mode=max
           #push: ${{ github.ref == 'refs/heads/main' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # TODO: append ,linux/arm64
           platforms: linux/amd64
-
-      - name: extract rust-cache from docker
-        uses: overmindtech/buildkit-cache-dance/extract@main
-        with:
-          cache-source: rust-cache
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,18 +44,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/login-action@v2
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-buildx-${{ steps.prep.outputs.semver }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-buildx-
 
       - uses: docker/build-push-action@v4
         with:
@@ -63,8 +55,7 @@ jobs:
           # official experimental: https://docs.docker.com/build/ci/github-actions/cache/#github-cache
           cache-from: type=gha,scope=version6
           cache-to: type=gha,scope=version6,mode=max
-          #push: ${{ github.ref == 'refs/heads/main' }}
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # TODO: append ,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,11 @@ jobs:
           echo "semver=${TAG}" >> $GITHUB_OUTPUT
           if curl -sSL https://registry.hub.docker.com/v1/repositories/${IMAGE}/tags | jq -r ".[].name" | grep -q ${TAG}; then
             echo "Semver tag ${TAG} already exists - not publishing"
-            echo "tags=${IMAGE}:latest" >> $GITHUB_OUTPUT
+            echo "enable_semver=true" >> $GITHUB_OUTPUT
+            # TODO: false
           else
             echo "Semver tag ${TAG} not found - publishing"
-            echo "tags=${IMAGE}:latest,${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+            echo "enable_semver=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Docker Buildx
@@ -40,8 +41,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.title=${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}},value=$(echo "1.3.0"))
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=semver,pattern={{version}},value=${{ steps.prep.outputs.semver }},enable=${{ steps.prep.outputs.enable_semver }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/login-action@v2
         #if: github.event_name != 'pull_request'

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -75,14 +75,11 @@ spec:
     metadata:
       labels:
         app: version
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8000"
     spec:
       serviceAccountName: version
       containers:
       - name: version
-        image: "clux/version:latest"
+        image: clux/version:latest
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
- Upgrades [build-push-action](https://github.com/docker/build-push-action) (less explicit about buildx)
- Upgrades meta action (tries using [latest setup](https://github.com/docker/metadata-action#latest-tag) + [semver setup](https://github.com/docker/metadata-action#typesemver))
- Fix caching (seems the layer caching now works with volumes, and repeat builds is now faster than lint)
- Fixes branch/master ref
- Change tagging to happen based on git tags instead (which is more common for private apps in the wild)

Hopefully this actually pushes now while testing. Will pin back at main after.