### PR TITLE
limit pushes to main and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Docker login
         uses: docker/login-action@v3
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -71,8 +71,7 @@ jobs:
           # when using buildkit-cache-dance
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          #push: ${{ github.ref == 'refs/heads/main' }}
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: ${{ matrix.platform }}
 


### PR DESCRIPTION
to prevent flooding artifact with dependabot pr-X images.